### PR TITLE
Fix build with 6.17-rc1

### DIFF
--- a/gsp_binding_test.rs
+++ b/gsp_binding_test.rs
@@ -9,7 +9,7 @@ use r570_144 as fw;
 module! {
     type: GspBindingTest,
     name: "GspBindings",
-    author: "Alistair Popple",
+    authors: ["Alistair Popple"],
     description: "GSP Binding Generation Stub Module",
     license: "GPL v2",
     firmware: [],


### PR DESCRIPTION
The `module` macro has been updated and trying to generate the bindings fails with the following error:

      RUSTC [M] gsp_binding_test.o
    error: proc macro panicked
      --> gsp_binding_test.rs:9:1
      |
    9  | / module! {
    10 | |     type: GspBindingTest,
    11 | |     name: "GspBindings",
    12 | |     author: "Alistair Popple",
    ...  |
    15 | |     firmware: [],
    16 | | }
      | |_^
      |
      = help: message: Unknown key "author". Valid keys are: ["type", "name", "authors", "description", "license", "alias", "firmware"].

    error[E0425]: cannot find value `__LOG_PREFIX` in the crate root
      --> gsp_binding_test.rs:23:9
      |
    23 |         pr_info!("GSP_FW_WPR_META_MAGIC = {}\n", fw::GSP_FW_WPR_META_MAGIC);
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in the crate root
      |
      = note: this error originates in the macro `$crate::print_macro` which comes from the expansion of the macro `pr_info` (in Nightly builds, run with -Z macro-backtrace for more info)

    error: aborting due to 2 previous errors

Fix this by using the `authors` as key and an array as value, as is now expected.