### PR TITLE
Sync with upstream

### DIFF
--- a/nvidia-open-gpu-symbols.txt
+++ b/nvidia-open-gpu-symbols.txt
@@ -34,3 +34,4 @@ type:msgqRxHeader
 type:rpc_message_header_v
 var:NV_VGPU_MSG_SIGNATURE_VALID
 type:GSP_MSG_QUEUE_ELEMENT
+type:GspStaticConfigInfo_t

--- a/nvidia-open-gpu-symbols.txt
+++ b/nvidia-open-gpu-symbols.txt
@@ -35,3 +35,4 @@ type:rpc_message_header_v
 var:NV_VGPU_MSG_SIGNATURE_VALID
 type:GSP_MSG_QUEUE_ELEMENT
 type:GspStaticConfigInfo_t
+type:rpc_run_cpu_sequencer_v17_00

--- a/nvidia-open-gpu-symbols.txt
+++ b/nvidia-open-gpu-symbols.txt
@@ -36,3 +36,4 @@ var:NV_VGPU_MSG_SIGNATURE_VALID
 type:GSP_MSG_QUEUE_ELEMENT
 type:GspStaticConfigInfo_t
 type:rpc_run_cpu_sequencer_v17_00
+type:GSP_SEQUENCER_BUFFER_CMD

--- a/nvidia-open-gpu-symbols.txt
+++ b/nvidia-open-gpu-symbols.txt
@@ -37,3 +37,4 @@ type:GSP_MSG_QUEUE_ELEMENT
 type:GspStaticConfigInfo_t
 type:rpc_run_cpu_sequencer_v17_00
 type:GSP_SEQUENCER_BUFFER_CMD
+type:rpc_unloading_guest_driver_v1F_07

--- a/nvidia-open-gpu-symbols.txt
+++ b/nvidia-open-gpu-symbols.txt
@@ -38,3 +38,5 @@ type:GspStaticConfigInfo_t
 type:rpc_run_cpu_sequencer_v17_00
 type:GSP_SEQUENCER_BUFFER_CMD
 type:rpc_unloading_guest_driver_v1F_07
+type:rpc_gsp_rm_alloc_v03_00
+type:rpc_gsp_rm_control_v03_00

--- a/r570_144.rs
+++ b/r570_144.rs
@@ -26,4 +26,5 @@
 
 #[allow(clippy::undocumented_unsafe_blocks)]
 use kernel::ffi;
+use pin_init::MaybeZeroable;
 include!("r570_144_bindings.rs");


### PR DESCRIPTION
This mostly syncs the current upstream state. The difference is that some missing padding was added, and `MaybeZeroable` is automatically derived. I have no idea how both happened. :)