### PR TITLE
Restore missing symbols and generate SPDX header

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -138,9 +138,9 @@ $(OPEN_GPU_KERNEL_VERSION)_bindings.rs: private bindgen_target_flags += \
         $(if $(filter type:%,$(item)),--allowlist-type=$(patsubst type:%,%,$(item)),\
         $(if $(filter var:%,$(item)),--allowlist-var=$(patsubst var:%,%,$(item)))))
 
-# Strip the bindgen version comment in the output to keep diffs clean
+# Replace the bindgen version comment with an SPDX license header
 $(OPEN_GPU_KERNEL_VERSION)_bindings.rs: private bindgen_target_extra = ; \
-	sed -Eni '3,$$p' $@
+	sed -Ei '1s|^/\*.*\*/$$|// SPDX-License-Identifier: GPL-2.0|' $@
 
 gsp_binding_test.o: $(OPEN_GPU_KERNEL_VERSION)_bindings.rs
 obj-m := gsp_binding_test.o

--- a/nvidia-open-gpu-symbols.txt
+++ b/nvidia-open-gpu-symbols.txt
@@ -34,3 +34,6 @@ type:msgqRxHeader
 type:rpc_message_header_v
 var:NV_VGPU_MSG_SIGNATURE_VALID
 type:GSP_MSG_QUEUE_ELEMENT
+type:rpc_run_cpu_sequencer_v17_00
+type:GSP_SEQUENCER_BUFFER_CMD
+type:GspStaticConfigInfo_t


### PR DESCRIPTION
These two commits fix the generator so it reproduces the checked-in
r570_144/bindings.rs with zero diff:

1. Restore the three types (GspStaticConfigInfo_t, rpc_run_cpu_sequencer_v17_00,
   GSP_SEQUENCER_BUFFER_CMD) that were removed in 3958268 but are now needed
   by nova-core.

2. Replace the bindgen version comment with an SPDX license header instead
   of stripping it, eliminating manual post-processing when copying bindings
   into the kernel tree.

Verified: `diff r570_144_bindings.rs drivers/gpu/nova-core/gsp/fw/r570_144/bindings.rs`
produces no output.